### PR TITLE
Fix NSOpenPanel undeclared identifier error

### DIFF
--- a/FindCacheDataOffset.m
+++ b/FindCacheDataOffset.m
@@ -1,3 +1,4 @@
+#import <AppKit/AppKit.h>
 @import Foundation;
 @import Darwin;
 @import MachO;


### PR DESCRIPTION
Add import for AppKit framework in `FindCacheDataOffset.m`.

* Import `AppKit` framework at the top of the file to recognize `NSOpenPanel` and `NSModalResponseOK` identifiers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AdvencedJavaProgramming/SparseBox/pull/2?shareId=eed042ce-84b4-40d2-92cd-517612ccef97).