### PR TITLE
Fix NSOpenPanel error in FindCacheDataOffset.m

### DIFF
--- a/FindCacheDataOffset.m
+++ b/FindCacheDataOffset.m
@@ -1,3 +1,4 @@
+#import <Cocoa/Cocoa.h>
 #import <AppKit/AppKit.h>
 @import Foundation;
 @import Darwin;


### PR DESCRIPTION
Fix the undeclared identifier errors in `FindCacheDataOffset.m`.

* Add `#import <Cocoa/Cocoa.h>` at the top of the file to ensure 'NSOpenPanel' and 'openPanel' are recognized.
* Retain the existing import of `<AppKit/AppKit.h>` and other imports.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AdvencedJavaProgramming/SparseBox/pull/3?shareId=188b990a-5762-4f33-a565-5e30a3955778).