### PR TITLE
Fix Cocoa import in FindCacheDataOffset.m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ libEMProxy_INSTALL_PATH = /Applications/$(APPLICATION_NAME).app/Frameworks
 
 # libimobiledevice + minimuxer
 libimobiledevice_FILES = idevicebackup2.c FindCacheDataOffset.m
-libimobiledevice_CFLAGS = -Iinclude -fobjc-arc
+libimobiledevice_CFLAGS = -Iinclude -fobjc-arc -F /System/Library/Frameworks
 libimobiledevice_LDFLAGS = \
   -force_load lib/libimobiledevice-1.0.a \
   -force_load lib/libimobiledevice-glue-1.0.a \
@@ -25,7 +25,8 @@ libimobiledevice_LDFLAGS = \
   -force_load lib/libssl.a \
   -force_load lib/libminimuxer-ios.a \
   -Wl,-mllvm,--opaque-pointers \
-  -install_name @rpath/libimobiledevice.dylib
+  -install_name @rpath/libimobiledevice.dylib \
+  -framework Cocoa
 libimobiledevice_FRAMEWORKS = Foundation Security SystemConfiguration
 libimobiledevice_INSTALL_PATH = /Applications/$(APPLICATION_NAME).app/Frameworks
 


### PR DESCRIPTION
Fix the 'Cocoa/Cocoa.h' file not found error in `FindCacheDataOffset.m`.

* **Makefile**
  - Add `-F /System/Library/Frameworks` to `libimobiledevice_CFLAGS` to specify framework search path.
  - Add `-framework Cocoa` to `libimobiledevice_LDFLAGS` to link Cocoa framework.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AdvencedJavaProgramming/SparseBox?shareId=XXXX-XXXX-XXXX-XXXX).